### PR TITLE
Correctly create and surface data service in Flink runner

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/EnvironmentSession.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/EnvironmentSession.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.runners.flink.execution;
 
+import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
 import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
 import org.apache.beam.runners.fnexecution.control.SdkHarnessClient;
@@ -44,4 +45,9 @@ public interface EnvironmentSession extends AutoCloseable {
    * Get an {@link SdkHarnessClient} that can communicate with an instance of the environment.
    */
   SdkHarnessClient getClient();
+
+  /**
+   * Get a {@link ApiServiceDescriptor} for the data service.
+   */
+  ApiServiceDescriptor getDataServiceDescriptor();
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceEnvironmentSession.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceEnvironmentSession.java
@@ -1,5 +1,6 @@
 package org.apache.beam.runners.flink.execution;
 
+import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
 import org.apache.beam.runners.fnexecution.control.SdkHarnessClient;
@@ -11,21 +12,23 @@ public class JobResourceEnvironmentSession implements EnvironmentSession {
   private final RunnerApi.Environment environment;
   private final ArtifactSource artifactSource;
   private final SdkHarnessClient client;
+  private final ApiServiceDescriptor dataServiceDescriptor;
 
   private boolean isClosed = false;
 
   public JobResourceEnvironmentSession(
       RunnerApi.Environment environment,
       ArtifactSource artifactSource,
-      SdkHarnessClient client) {
+      SdkHarnessClient client,
+      ApiServiceDescriptor dataServiceDescriptor) {
     this.environment = environment;
     this.artifactSource = artifactSource;
     this.client = client;
+    this.dataServiceDescriptor = dataServiceDescriptor;
   }
 
   @Override
   public RunnerApi.Environment getEnvironment() {
-    validateNotClosed();
     return environment;
   }
 
@@ -39,6 +42,11 @@ public class JobResourceEnvironmentSession implements EnvironmentSession {
   public SdkHarnessClient getClient() {
     validateNotClosed();
     return client;
+  }
+
+  @Override
+  public ApiServiceDescriptor getDataServiceDescriptor() {
+    return dataServiceDescriptor;
   }
 
   /**

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceFactory.java
@@ -61,20 +61,27 @@ public class JobResourceFactory {
   }
 
   /** Create a new control service. */
-  private GrpcFnServer<SdkHarnessClientControlService> controlService() throws IOException {
-    FnDataService dataService = GrpcDataService.create(executor);
+  private GrpcFnServer<SdkHarnessClientControlService> controlService(GrpcDataService dataService)
+      throws IOException {
     SdkHarnessClientControlService controlService =
         SdkHarnessClientControlService.create(() -> dataService);
     return GrpcFnServer.allocatePortAndCreateFor(controlService, serverFactory);
   }
 
+  /** Create a new data service. */
+  public GrpcFnServer<GrpcDataService> dataService() throws IOException {
+    GrpcDataService dataService = GrpcDataService.create(executor);
+    return GrpcFnServer.allocatePortAndCreateFor(dataService, serverFactory);
+  }
+
   /** Create a new container manager from artifact source and jobInfo. */
-  EnvironmentManager containerManager(ArtifactSource artifactSource, ProvisionInfo jobInfo)
+  EnvironmentManager containerManager(
+      ArtifactSource artifactSource, ProvisionInfo jobInfo, GrpcDataService dataService)
       throws IOException {
     return SingletonDockerEnvironmentManager.forServices(
         // TODO: Replace hardcoded values with configurable ones
         DockerWrapper.forCommand("docker", Duration.ofSeconds(30)),
-        controlService(),
+        controlService(dataService),
         loggingService(),
         artifactRetrievalService(artifactSource),
         provisionService(jobInfo)


### PR DESCRIPTION
The data service was not previously being created correctly, and its
API service descriptor needed to be surfaced to the Flink operator.
The data service is now lazily instantiated by a JobResourceManager, and
surfaced to the Flink operator via the EnvironmentSession.

DO NOT MERGE until base branch flink-portable-runner is fixed and this
commit can be rebased.  It does not currently compile, preventing
checking compile errors.
