### PR TITLE
Add Flink ArtifactSource implementation

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkCachedArtifactPaths.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkCachedArtifactPaths.java
@@ -1,0 +1,31 @@
+package org.apache.beam.runners.flink;
+
+/**
+ * Determines artifact path names within the
+ * {@link org.apache.flink.api.common.cache.DistributedCache}.
+ */
+public class FlinkCachedArtifactPaths {
+  private static final String DEFAULT_ARTIFACT_TOKEN = "default";
+
+  public static FlinkCachedArtifactPaths createDefault() {
+    return new FlinkCachedArtifactPaths(DEFAULT_ARTIFACT_TOKEN);
+  }
+
+  public static FlinkCachedArtifactPaths forToken(String artifactToken) {
+    return new FlinkCachedArtifactPaths(artifactToken);
+  }
+
+  private final String token;
+
+  private FlinkCachedArtifactPaths(String token) {
+    this.token = token;
+  }
+
+  public String getArtifactPath(String name) {
+    return String.format("ARTIFACT_%s_%s", token, name);
+  }
+
+  public String getManifestPath() {
+    return String.format("MANIFEST_%s", token);
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/FlinkArtifactSource.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/FlinkArtifactSource.java
@@ -1,0 +1,77 @@
+package org.apache.beam.runners.flink.execution;
+
+
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.apache.beam.model.jobmanagement.v1.ArtifactApi.ArtifactChunk;
+import org.apache.beam.model.jobmanagement.v1.ArtifactApi.Manifest;
+import org.apache.beam.runners.flink.FlinkCachedArtifactPaths;
+import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
+import org.apache.flink.api.common.cache.DistributedCache;
+
+/**
+ * An {@link org.apache.beam.runners.fnexecution.artifact.ArtifactSource} that draws artifacts
+ * from the Flink Distributed File Cache {@link org.apache.flink.api.common.cache.DistributedCache}.
+ */
+public class FlinkArtifactSource implements ArtifactSource {
+  private static final int DEFAULT_CHUNK_SIZE_BYTES = 2 * 1024 * 1024;
+
+  public static FlinkArtifactSource createDefault(DistributedCache cache) {
+    return new FlinkArtifactSource(cache, FlinkCachedArtifactPaths.createDefault());
+  }
+
+  public static FlinkArtifactSource forToken(DistributedCache cache, String artifactToken) {
+    return new FlinkArtifactSource(cache, FlinkCachedArtifactPaths.forToken(artifactToken));
+  }
+
+  private final DistributedCache cache;
+  private final FlinkCachedArtifactPaths paths;
+
+  private FlinkArtifactSource(DistributedCache cache, FlinkCachedArtifactPaths paths) {
+    this.cache = cache;
+    this.paths = paths;
+  }
+
+  @Override
+  public Manifest getManifest() throws IOException {
+    String path = paths.getManifestPath();
+    File manifest = cache.getFile(path);
+    try (BufferedInputStream fStream = new BufferedInputStream(new FileInputStream(manifest))) {
+      return Manifest.parseFrom(fStream);
+
+    }
+  }
+
+  @Override
+  public void getArtifact(String name, StreamObserver<ArtifactChunk> responseObserver) {
+    String path = paths.getArtifactPath(name);
+    File artifact = cache.getFile(path);
+    try (FileInputStream fStream = new FileInputStream(artifact)) {
+      byte[] buffer = new byte[DEFAULT_CHUNK_SIZE_BYTES];
+      for (int bytesRead = fStream.read(buffer); bytesRead > 0; bytesRead = fStream.read(buffer)) {
+        ByteString data = ByteString.copyFrom(buffer, 0, bytesRead);
+        responseObserver.onNext(ArtifactChunk.newBuilder().setData(data).build());
+      }
+      responseObserver.onCompleted();
+    } catch (FileNotFoundException e) {
+      responseObserver.onError(
+          Status.INVALID_ARGUMENT
+              .withDescription(String.format("No such artifact %s", name))
+              .withCause(e)
+              .asException());
+    } catch (Exception e) {
+      responseObserver.onError(
+          Status.INTERNAL
+              .withDescription(
+                  String.format("Could not retrieve artifact with name %s", name))
+              .withCause(e)
+              .asException());
+    }
+  }
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactSource.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactSource.java
@@ -18,8 +18,11 @@
 
 package org.apache.beam.runners.fnexecution.artifact;
 
-import java.util.stream.Stream;
-import org.apache.beam.model.jobmanagement.v1.ArtifactApi;
+import java.io.IOException;
+
+import io.grpc.stub.StreamObserver;
+import org.apache.beam.model.jobmanagement.v1.ArtifactApi.ArtifactChunk;
+import org.apache.beam.model.jobmanagement.v1.ArtifactApi.Manifest;
 
 /**
  * Makes artifacts available to an ArtifactRetrievalService by
@@ -30,10 +33,10 @@ public interface ArtifactSource {
   /**
    * Get the artifact manifest available from this source.
    */
-  ArtifactApi.Manifest getManifest();
+  Manifest getManifest() throws IOException;
 
   /**
    * Get an artifact by its name.
    */
-  Stream<ArtifactApi.ArtifactChunk> getArtifact(String name);
+  void getArtifact(String name, StreamObserver<ArtifactChunk> responseObserver);
 }


### PR DESCRIPTION
The Flink operator will need to pass an ArtifactSource to the
SdkHarnessManager when obtaining an EnvironmentSession.  This commit
adds an ArtifactSource implementation based off of the Flink distributed
cache.