### PR TITLE
Add logging to Flink runner portability classes

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/FlinkArtifactSource.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/FlinkArtifactSource.java
@@ -14,12 +14,15 @@ import org.apache.beam.model.jobmanagement.v1.ArtifactApi.Manifest;
 import org.apache.beam.runners.flink.FlinkCachedArtifactPaths;
 import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
 import org.apache.flink.api.common.cache.DistributedCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An {@link org.apache.beam.runners.fnexecution.artifact.ArtifactSource} that draws artifacts
  * from the Flink Distributed File Cache {@link org.apache.flink.api.common.cache.DistributedCache}.
  */
 public class FlinkArtifactSource implements ArtifactSource {
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkArtifactSource.class);
   private static final int DEFAULT_CHUNK_SIZE_BYTES = 2 * 1024 * 1024;
 
   public static FlinkArtifactSource createDefault(DistributedCache cache) {
@@ -41,6 +44,7 @@ public class FlinkArtifactSource implements ArtifactSource {
   @Override
   public Manifest getManifest() throws IOException {
     String path = paths.getManifestPath();
+    LOG.debug("Retrieving manifest {}.", path);
     File manifest;
     try {
       // cache.geFile throws an IllegalArgumentException for unrecognized paths
@@ -56,6 +60,7 @@ public class FlinkArtifactSource implements ArtifactSource {
   @Override
   public void getArtifact(String name, StreamObserver<ArtifactChunk> responseObserver) {
     String path = paths.getArtifactPath(name);
+    LOG.debug("Retrieving artifact {}.", path);
     try {
       // cache.geFile throws an IllegalArgumentException for unrecognized paths
       File artifact = cache.getFile(path);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceManager.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceManager.java
@@ -8,6 +8,8 @@ import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
 import org.apache.beam.runners.fnexecution.data.GrpcDataService;
 import org.apache.beam.runners.fnexecution.environment.EnvironmentManager;
 import org.apache.beam.runners.fnexecution.environment.RemoteEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class that manages the long-lived resources of an individual job.
@@ -15,6 +17,7 @@ import org.apache.beam.runners.fnexecution.environment.RemoteEnvironment;
  * <p>Only one harness environment is currently supported per job.
  */
 public class JobResourceManager {
+  private static final Logger LOG = LoggerFactory.getLogger(JobResourceManager.class);
 
   /** Create a new JobResourceManager. */
   public static JobResourceManager create(
@@ -53,6 +56,7 @@ public class JobResourceManager {
 
   /** Get a new environment session using the manager's resources. */
   public EnvironmentSession getSession() {
+    LOG.info("Creating new enironment session for Job {}.", jobInfo.getJobName());
     if (!isStarted()) {
       throw new IllegalStateException("JobResourceManager has not been properly initialized.");
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceManagerFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceManagerFactory.java
@@ -5,11 +5,14 @@ import org.apache.beam.model.fnexecution.v1.ProvisionApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.fnexecution.ServerFactory;
 import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Factory which creates {@link JobResourceManager JobResourceManagers}.
  */
 public class JobResourceManagerFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(JobResourceManagerFactory.class);
 
   public static JobResourceManagerFactory create() {
     return new JobResourceManagerFactory();
@@ -25,6 +28,7 @@ public class JobResourceManagerFactory {
       ServerFactory serverFactory,
       ExecutorService executor) {
     JobResourceFactory jobResourceFactory = JobResourceFactory.create(serverFactory, executor);
+    LOG.info("Creating job resource manager for Job {}.", jobInfo.getJobName());
     return JobResourceManager
         .create(jobInfo, environment, artifactSource, jobResourceFactory);
   }


### PR DESCRIPTION
Some of the new portability classes in the Flink runner needed better logging.  The new changes create log records for significant events such as the starting of gRPC servers and creation of high-level resources in the Flink worker.

