### PR TITLE
Choose batch or streaming backend based on unbounded PCollections

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
@@ -80,8 +80,8 @@ public class FlinkJobInvocation implements JobInvocation {
     RunnerApi.Pipeline fusedPipeline = GreedyPipelineFuser.fuse(pipeline).toPipeline();
     final JobExecutionResult result;
 
-    // TODO: discover unbounded sources for streaming translation
-    if (true) {
+    if (!FlinkTranslationUtils.hasUnboundedPCollecctions(fusedPipeline)) {
+      // TODO: Do we need to inspect for unbounded sources before fusing?
       // batch translation
       FlinkBatchPortablePipelineTranslator translator = new FlinkBatchPortablePipelineTranslator();
       FlinkBatchPortablePipelineTranslator.BatchTranslationContext context =

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkTranslationUtils.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkTranslationUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Collection;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+
+/**
+ * Common translation utilities.
+ */
+public class FlinkTranslationUtils {
+
+  /** Indicates whether the given pipeline has any unbounded PCollections. */
+  public static boolean hasUnboundedPCollecctions(RunnerApi.Pipeline pipeline) {
+    checkArgument(pipeline != null);
+    Collection<RunnerApi.PCollection> pCollecctions = pipeline.getComponents()
+        .getPcollectionsMap().values();
+    // Assume that all PCollections are consumed at some point in the pipeline.
+    return pCollecctions.stream()
+        .anyMatch(pc -> pc.getIsBounded() == RunnerApi.IsBounded.Enum.UNBOUNDED);
+  }
+}


### PR DESCRIPTION
This assumes that all PCollections within a given Pipeline's components are consumed by the pipeline at some point. If we want to discount PCollections that are completely detached from the pipeline, this will need to be detected.