### PR TITLE
Add WordCount java exec target for PortableRunner

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -151,3 +151,9 @@ task preCommit() {
   }
 }
 
+task runWordCount(type: JavaExec) {
+  classpath = configurations.shadow + sourceSets.main.runtimeClasspath
+  println("CLASSPATH: ${configurations.shadow.asPath}")
+  main = "org.apache.beam.examples.WordCount"
+  args "--runner=org.apache.beam.runners.reference.PortableRunner"
+}


### PR DESCRIPTION
Allows quick WordCount testing against the portable runner.