### PR TITLE
Wire job service API into portable runner PipelineResults

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
@@ -194,7 +194,7 @@ public class WordCount {
         }
       }));
 
-    p.run();
+    p.run().waitUntilFinish();
   }
 
   public static void main(String[] args) {

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/CloseableResource.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/CloseableResource.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.reference;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * An {@link AutoCloseable} that wraps a resource that needs to be cleaned up but does not implement
+ * {@link AutoCloseable} itself. Recipients of a {@link CloseableResource} are in general
+ * responsible for cleanup. Not thread-safe.
+ */
+public class CloseableResource<T> implements AutoCloseable {
+
+  private final T resource;
+  private final Closer<T> closer;
+
+  private boolean isClosed = false;
+
+  private CloseableResource(T resource, Closer<T> closer) {
+    this.resource = resource;
+    this.closer = closer;
+  }
+
+  /** Creates a {@link CloseableResource} with the given resource and closer. */
+  public static <T> CloseableResource<T> of(T resource, Closer<T> closer) {
+    return new CloseableResource<>(resource, closer);
+  }
+
+  /** Gets the underlying resource. */
+  public T get() {
+    checkState(!isClosed, "% is closed", CloseableResource.class.getName());
+    return resource;
+  }
+
+  /**
+   * Close the underlying resource. Must only be called once.
+   * @throws CloseException wrapping any exceptions thrown while closing
+   */
+  @Override
+  public void close() throws CloseException {
+    checkState(!isClosed, "% is closed", CloseableResource.class.getName());
+    try {
+      closer.close(resource);
+    } catch (Exception e) {
+      throw new CloseException(e);
+    }
+    isClosed = true;
+  }
+
+  /** A function that knows how to clean up after a resource. */
+  @FunctionalInterface
+  public interface Closer<T> {
+    void close(T resource) throws Exception;
+  }
+
+  /** An exception that wraps errors thrown while a resource is being closed. */
+  public static class CloseException extends Exception {
+    private CloseException(Exception e) {
+      super("Error closing resource", e);
+    }
+  }
+}

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/JobServicePipelineResult.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/JobServicePipelineResult.java
@@ -17,36 +17,125 @@
  */
 package org.apache.beam.runners.reference;
 
-import java.io.IOException;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.google.protobuf.ByteString;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.beam.model.jobmanagement.v1.JobApi;
+import org.apache.beam.model.jobmanagement.v1.JobApi.CancelJobRequest;
+import org.apache.beam.model.jobmanagement.v1.JobApi.CancelJobResponse;
+import org.apache.beam.model.jobmanagement.v1.JobApi.GetJobStateRequest;
+import org.apache.beam.model.jobmanagement.v1.JobApi.GetJobStateResponse;
+import org.apache.beam.model.jobmanagement.v1.JobServiceGrpc.JobServiceBlockingStub;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class JobServicePipelineResult implements PipelineResult {
 
-  @Override
-  public State getState() {
-    throw new UnsupportedOperationException("Not yet implemented.");
+  private static final long POLL_INTERVAL_SEC = 10;
+
+  private static final Logger LOG = LoggerFactory.getLogger(JobServicePipelineResult.class);
+
+  private final ByteString jobId;
+  private final CloseableResource<JobServiceBlockingStub> jobService;
+
+  JobServicePipelineResult(ByteString jobId, CloseableResource<JobServiceBlockingStub> jobService) {
+    this.jobId = jobId;
+    this.jobService = jobService;
   }
 
   @Override
-  public State cancel() throws IOException {
-    throw new UnsupportedOperationException("Not yet implemented.");
+  public State getState() {
+    JobServiceBlockingStub stub = jobService.get();
+    GetJobStateResponse response = stub.getState(
+        GetJobStateRequest.newBuilder().setJobIdBytes(jobId).build());
+    return getJavaState(response.getState());
+  }
+
+  @Override
+  public State cancel() {
+    JobServiceBlockingStub stub = jobService.get();
+    CancelJobResponse response = stub.cancel(
+        CancelJobRequest.newBuilder().setJobIdBytes(jobId).build());
+    return getJavaState(response.getState());
 
   }
 
   @Override
   public State waitUntilFinish(Duration duration) {
-    throw new UnsupportedOperationException("Not yet implemented.");
+    if (duration.compareTo(Duration.millis(1)) < 1) {
+      // Equivalent to infinite timeout.
+      return waitUntilFinish();
+    } else {
+      CompletableFuture<State> result = CompletableFuture.supplyAsync(this::waitUntilFinish);
+      try {
+        return Uninterruptibles.getUninterruptibly(
+            result, duration.getMillis(), TimeUnit.MILLISECONDS);
+      } catch (TimeoutException e) {
+        // Null result indicates a timeout.
+        return null;
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   @Override
   public State waitUntilFinish() {
-    throw new UnsupportedOperationException("Not yet implemented.");
+    JobServiceBlockingStub stub = jobService.get();
+    GetJobStateRequest request = GetJobStateRequest.newBuilder().setJobIdBytes(jobId).build();
+    State lastState;
+    do {
+      Uninterruptibles.sleepUninterruptibly(POLL_INTERVAL_SEC, TimeUnit.SECONDS);
+      GetJobStateResponse response = stub.getState(request);
+      lastState = getJavaState(response.getState());
+    } while (!lastState.isTerminal());
+    try {
+      jobService.close();
+    } catch (Exception e) {
+      LOG.warn("Error cleaning up job service", e);
+    }
+    return lastState;
   }
 
   @Override
   public MetricResults metrics() {
     throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  private static State getJavaState(JobApi.JobState.Enum protoState) {
+    switch (protoState) {
+      case UNSPECIFIED:
+        return State.UNKNOWN;
+      case STOPPED:
+        return State.STOPPED;
+      case RUNNING:
+        return State.RUNNING;
+      case DONE:
+        return State.DONE;
+      case FAILED:
+        return State.FAILED;
+      case CANCELLED:
+        return State.CANCELLED;
+      case UPDATED:
+        return State.UPDATED;
+      case DRAINING:
+        // TODO: Determine the correct mappings for the states below.
+        return State.UNKNOWN;
+      case DRAINED:
+        return State.UNKNOWN;
+      case STARTING:
+        return State.RUNNING;
+      case CANCELLING:
+        return State.CANCELLED;
+      default:
+        LOG.warn("Unrecognized state from server: {}", protoState);
+        return State.UNKNOWN;
+    }
   }
 }


### PR DESCRIPTION
This allows pipeline clients to block on pipeline completion.