### PR TITLE
Fix artifact stager test

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ArtifactServiceStager.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ArtifactServiceStager.java
@@ -246,7 +246,7 @@ public class ArtifactServiceStager {
     abstract Map<File, Throwable> getFailures();
   }
 
-  private static String escapePath(String path) {
+  static String escapePath(String path) {
     StringBuilder result = new StringBuilder(path.length() * 2);
     for (int i = 0; i < path.length(); i++) {
       char c = path.charAt(i);

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ArtifactServiceStagerTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ArtifactServiceStagerTest.java
@@ -94,7 +94,7 @@ public class ArtifactServiceStagerTest {
     assertThat(stagedContent, equalTo(content));
 
     ArtifactMetadata staged = service.getManifest().getArtifact(0);
-    assertThat(staged.getName(), equalTo(file.getName()));
+    assertThat(staged.getName(), equalTo(ArtifactServiceStager.escapePath(file.getPath())));
     byte[] manifestMd5 = BaseEncoding.base64().decode(staged.getMd5());
     assertArrayEquals(contentMd5, manifestMd5);
 


### PR DESCRIPTION
The artifact stager now escapes path names and the test needs to be updated.