### PR TITLE
Nit: Validate not closed when accessing state delegator.

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceEnvironmentSession.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/execution/JobResourceEnvironmentSession.java
@@ -80,6 +80,7 @@ public class JobResourceEnvironmentSession implements EnvironmentSession {
 
   @Override
   public StateDelegator getStateDelegator() {
+    validateNotClosed();
     return stateDelegator;
   }
 


### PR DESCRIPTION
When accessing a mutable resource wrapped by
JobResourceEnvironmentSession, it should validate that it is not
closed.  The expectation is that accessing these fields after
close runs the risk of commencing communication to resources that
are no longer available.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

