### PR TITLE
Length-prefix unknown coders during Flink translation

### DIFF
--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CoderTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CoderTranslationTest.java
@@ -151,31 +151,6 @@ public class CoderTranslationTest {
       }
     }
 
-    @Test
-    public void testToProtoFromKnownCoderOrByteArray() throws IOException {
-      SdkComponents componentsBuilder = SdkComponents.create();
-      RunnerApi.Coder coderProto = CoderTranslation.toProto(coder, componentsBuilder);
-
-      Components encodedComponents = componentsBuilder.toComponents();
-      Coder<?> decodedCoder =
-          CoderTranslation.knownCoderOrByteArrayCoder(coderProto, encodedComponents.getCodersMap());
-
-      assertUnknownCodersByteArray(decodedCoder);
-    }
-
-    private <T> void assertUnknownCodersByteArray(Coder<T> coder) {
-      if (KNOWN_CODERS
-          .stream()
-          .map(Coder::getClass)
-          .anyMatch(clazz -> clazz.equals(coder.getClass()))) {
-        for (Coder<?> component : coder.getCoderArguments()) {
-          assertUnknownCodersByteArray(component);
-        }
-      } else {
-        assertThat(coder, Matchers.isA((Class) ByteArrayCoder.class));
-      }
-    }
-
     static class Record implements Serializable {}
 
     private static class RecordCoder extends AtomicCoder<Record> {


### PR DESCRIPTION
There was previously a mismatch between instantiated coder types on the executable stage gRPC nodes and the coders used for Flink DataSet TypeInformation. The associated TypeInformations now use the same coder construction as ExecutableStages.

I have also removed some unused code from CoderTranslation.
